### PR TITLE
Finalize objects before exiting

### DIFF
--- a/usb/_objfinalizer.py
+++ b/usb/_objfinalizer.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014 André Erdmann
+#
+# The following terms apply to all files associated
+# with the software unless explicitly disclaimed in individual files.
+#
+# The authors hereby grant permission to use, copy, modify, distribute,
+# and license this software and its documentation for any purpose, provided
+# that existing copyright notices are retained in all copies and that this
+# notice is included verbatim in any distributions. No written agreement,
+# license, or royalty fee is required for any of the authorized uses.
+# Modifications to this software may be copyrighted by their authors
+# and need not follow the licensing terms described here, provided that
+# the new terms are clearly indicated on the first page of each file where
+# they apply.
+#
+# IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+# FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+# ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+# DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+# IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+# NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
+from __future__ import print_function  # FIXME DBGPRINT
+
+import sys
+
+__all__ = ['AutoFinalizedObject']
+
+
+class _AutoFinalizedObjectBase(object):
+    """
+    Base class for objects that get automatically
+    finalized on delete or at exit.
+    """
+
+    def _finalize_object(self):
+        """Actually finalizes the object (frees allocated resources etc.).
+
+        Returns: None
+
+        Derived classes should implement this.
+        """
+        pass
+
+    def __new__(cls, *args, **kwargs):
+        """Creates a new object instance and adds the private finalizer
+        attributes to it.
+
+        Returns: new object instance
+
+        Arguments:
+        * *args, **kwargs -- ignored
+        """
+        instance = super(_AutoFinalizedObjectBase, cls).__new__(cls)
+        instance._finalize_called = False
+        return instance
+
+    def _do_finalize_object(self):
+        """Helper method that finalizes the object if not already done.
+
+        Returns: None
+        """
+        if not self._finalize_called: # race-free?
+            self._finalize_called = True
+            print("finalize " + repr(self))  # FIXME DBGPRINT
+            self._finalize_object()
+
+    def finalize(self):
+        """Finalizes the object if not already done.
+
+        Returns: None
+        """
+        # this is the "public" finalize method
+        raise NotImplementedError(
+            "finalize() must be implemented by AutoFinalizedObject."
+        )
+
+    def __del__(self):
+        self.finalize()
+
+
+if sys.hexversion >= 0x3040000:
+    # python >= 3.4: use weakref.finalize
+    import weakref
+
+    def _do_finalize_object_ref(obj_ref):
+        """Helper function for weakref.finalize() that dereferences a weakref
+        to an object and calls its _do_finalize_object() method if the object
+        is still alive. Does nothing otherwise.
+
+        Returns: None (implicit)
+
+        Arguments:
+        * obj_ref -- weakref to an object
+        """
+        print("finalize-ref " + repr(obj_ref))  # FIXME DBGPRINT
+        obj = obj_ref()
+        if obj is not None:
+            # else object disappeared
+            obj._do_finalize_object()
+
+
+    class AutoFinalizedObject(_AutoFinalizedObjectBase):
+
+        def __new__(cls, *args, **kwargs):
+            """Creates a new object instance and adds the private finalizer
+            attributes to it.
+
+            Returns: new object instance
+
+            Arguments:
+            * *args, **kwargs -- passed to the parent instance creator
+                                 (which ignores them)
+            """
+            # Note:   Do not pass a (hard) reference to instance to the
+            #         finalizer as func/args/kwargs, it'd keep the object
+            #         alive until the program terminates.
+            #         A weak reference is fine.
+            #
+            # Note 2: When using weakrefs and not calling finalize() in
+            #         __del__, the object may already have disappeared
+            #         when weakref.finalize() kicks in.
+            #         Make sure that _finalizer() gets called,
+            #         i.e. keep __del__() from the base class.
+            #
+            # Note 3: the _finalize_called attribute is (probably) useless
+            #         for this class
+            instance = super(AutoFinalizedObject, cls).__new__(
+                cls, *args, **kwargs
+            )
+
+            instance._finalizer = weakref.finalize(
+                instance, _do_finalize_object_ref, weakref.ref(instance)
+            )
+
+            return instance
+
+        def finalize(self):
+            """Finalizes the object if not already done."""
+            self._finalizer()
+
+
+else:
+    # python < 3.4: keep the old behavior (rely on __del__),
+    #                but don't call _finalize_object() more than once
+
+    class AutoFinalizedObject(_AutoFinalizedObjectBase):
+
+        def finalize(self):
+            """Finalizes the object if not already done."""
+            self._do_finalize_object()

--- a/usb/backend/__init__.py
+++ b/usb/backend/__init__.py
@@ -71,6 +71,8 @@ defaults backend according to its internal rules. For details, consult the
 find() function documentation.
 """
 
+import usb._objfinalizer as _objfinalizer
+
 __author__ = 'Wander Lairson Costa'
 
 __all__ = ['IBackend', 'libusb01', 'libusb10', 'openusb']
@@ -78,7 +80,7 @@ __all__ = ['IBackend', 'libusb01', 'libusb10', 'openusb']
 def _not_implemented(func):
     raise NotImplementedError(func.__name__)
 
-class IBackend(object):
+class IBackend(_objfinalizer.AutoFinalizedObject):
     r"""Backend interface.
 
     IBackend is the basic interface for backend implementations. By default,

--- a/usb/core.py
+++ b/usb/core.py
@@ -47,6 +47,7 @@ import usb.util as util
 import copy
 import operator
 import usb._interop as _interop
+import usb._objfinalizer as _objfinalizer
 import usb._lookup as _lu
 import logging
 import array
@@ -644,7 +645,7 @@ class Configuration(object):
             _lu.MAX_POWER_UNITS_USB2p0 * self.bMaxPower)
             # FIXME : add a check for superspeed vs usb 2.0
 
-class Device(object):
+class Device(_objfinalizer.AutoFinalizedObject):
     r"""Device object.
 
     This class contains all fields of the Device Descriptor according to the
@@ -1025,7 +1026,7 @@ class Device(object):
         r"""Return the Configuration object in the given position."""
         return Configuration(self, index)
 
-    def __del__(self):
+    def _finalize_object(self):
         self._ctx.dispose(self)
 
     def __get_timeout(self, timeout):

--- a/usb/legacy.py
+++ b/usb/legacy.py
@@ -29,6 +29,7 @@
 import usb.core as core
 import usb.util as util
 import usb._interop as _interop
+import usb._objfinalizer as _objfinalizer
 import usb.control as control
 
 __author__ = 'Wander Lairson Costa'
@@ -130,12 +131,12 @@ class Configuration(object):
                                     lambda i: i.alternateSetting)
                         ]
 
-class DeviceHandle(object):
+class DeviceHandle(_objfinalizer.AutoFinalizedObject):
     def __init__(self, dev):
         self.dev = dev
         self.__claimed_interface = None
 
-    def __del__(self):
+    def _finalize_object(self):
         util.dispose_resources(self.dev)
         self.dev = None
 


### PR DESCRIPTION
This should fix issue #66:

> Starting with (C)Python 3.4, the GC features "Safe object finalization" [0],
> which doesn't work nicely with pyusb's object structure.
>
> Required globals / modules may already have been deleted (set to None)
> when an object's __del__() method gets called [1], which
> randomly breaks libusb calls etc. when calling sys.exit().
>
> Use the atexit module to solve this (indirectly via weakref.finalize()).
>
> This commit adds a class that takes care of object finalization.
> Classes/objects can adopt this functionality by inheriting
> AutoFinalizedObject and renaming their __del__() method to _finalize_object().
>
> Shouldn't break existing use cases, but adds a few layers of indirection.
> A __del__() call gets processed as follows:
> 
>   __del__() -> finalize() -> [...]
>     -> _do_finalize_object() ->  _finalize_object()
>
> All methods in this call chain are provided by AutoFinalizedObject,
> derived classes should override the no-op _finalize_object() method.
>
> The "[...]" part depends on the python version:
> * <  3.4: <nothing>
> * >= 3.4: _finalizer() -> _do_finalize_object_ref()
> 

Needs testing, esp. with Python < 2.7.

The ``FIXME DBGPRINT`` lines should be removed when merging ;)