### PR TITLE
Add port_numbers device property

### DIFF
--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -52,7 +52,8 @@ class _DeviceDescriptor(object):
         self.bDeviceProtocol = 0xff
         self.bus = 1
         self.address = 1
-        self.port_number= None
+        self.port_number = None
+        self.port_numbers = None
 
 # We are only interested in test usb.find() function, we don't need
 # to implement all IBackend stuff

--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -185,6 +185,7 @@ class _DeviceDescriptor:
         self.bus = dev.bus[0].location
 
         self.port_number = None
+        self.port_numbers = None
 _lib = None
 
 def _load_library(find_library=None):

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -710,7 +710,7 @@ class _LibUSB(usb.backend.IBackend):
             written = dev_desc.port_numbers = self.lib.libusb_get_port_numbers(
                     dev.devid, buff, len(buff))
             if written > 0:
-                dev_desc.port_numbers = ".".join(map(str, buff[:written]))
+                dev_desc.port_numbers = tuple(buff[:written])
             else:
                 dev_desc.port_numbers = None
         except AttributeError:

--- a/usb/backend/openusb.py
+++ b/usb/backend/openusb.py
@@ -560,6 +560,7 @@ class _OpenUSB(usb.backend.IBackend):
         desc.bus = None
         desc.address = None
         desc.port_number = None
+        desc.port_numbers = None
         return desc
 
     @methodtrace(_logger)

--- a/usb/core.py
+++ b/usb/core.py
@@ -735,7 +735,8 @@ class Device(object):
                     'bNumConfigurations',
                     'address',
                     'bus',
-                    'port_number'
+                    'port_number',
+                    'port_numbers',
                 )
             )
 


### PR DESCRIPTION
Add port_numbers device property (not to be confused with existing port_number). This just wraps libusb_get_port_numbers(...) and presents the result as a tuple.

Usage: my application uses this function to find a USB device after it has re-enumerated as a bootloader with different VID and PID, but the same physical port location.

My first implementation used a string, but upon further reflection I determined that a tuple was a more natural representation, as the tuple can easily be converted to a string if necessary (and the reverse is a bit trickier).