### PR TITLE
Support for getting usb device speed

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -712,6 +712,7 @@ class _LibUSB(usb.backend.IBackend):
         _check(self.lib.libusb_get_device_descriptor(dev.devid, byref(dev_desc)))
         dev_desc.bus = self.lib.libusb_get_bus_number(dev.devid)
         dev_desc.address = self.lib.libusb_get_device_address(dev.devid)
+        dev_desc.speed = self.lib.libusb_get_device_speed(dev.devid)
 
         # Only available in newer versions of libusb
         try:

--- a/usb/core.py
+++ b/usb/core.py
@@ -738,6 +738,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
                     'bus',
                     'port_number',
                     'port_numbers',
+                    'speed',
                 )
             )
 
@@ -755,6 +756,11 @@ class Device(_objfinalizer.AutoFinalizedObject):
             self.port_number = int(desc.port_number)
         else:
             self.port_number = None
+
+        if desc.speed is not None:
+            self.speed = int(desc.speed)
+        else:
+            self.speed = None 
 
     @property
     def serial_number(self):

--- a/usb/util.py
+++ b/usb/util.py
@@ -89,6 +89,13 @@ _CTRL_DIR_MASK = 0x80
 # For compatibility between Python 2 and 3
 _dummy_s = '\x00'.encode('utf-8')
 
+# speed type
+SPEED_LOW = 1
+SPEED_FULL = 2
+SPEED_HIGH = 3
+SPEED_SUPER = 4
+SPEED_UNKNOWN = 0
+
 def endpoint_address(address):
     r"""Return the endpoint absolute address.
 


### PR DESCRIPTION
In some cases, we need to get the usb device speed type to attach
it to specific usb controller. Fortunately, it's easy to get usb
device speed information with libusb1.0.