### PR TITLE
Support the libusb0 that ships in Solaris

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -46,7 +46,7 @@ _logger = logging.getLogger('usb.backend.libusb0')
 # usb.h
 
 if sys.platform.find('bsd') != -1 or sys.platform.find('mac') != -1 or \
-        sys.platform.find('darwin') != -1:
+        sys.platform.find('darwin') != -1 or sys.platform.find('sunos5') != -1:
     _PATH_MAX = 1024
 elif sys.platform == 'win32' or sys.platform == 'cygwin':
     _PATH_MAX = 511

--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -45,15 +45,13 @@ _logger = logging.getLogger('usb.backend.libusb0')
 
 # usb.h
 
-_PC_PATH_MAX = 4
-
 if sys.platform.find('bsd') != -1 or sys.platform.find('mac') != -1 or \
         sys.platform.find('darwin') != -1:
     _PATH_MAX = 1024
 elif sys.platform == 'win32' or sys.platform == 'cygwin':
     _PATH_MAX = 511
 else:
-    _PATH_MAX = os.pathconf('.', _PC_PATH_MAX)
+    _PATH_MAX = os.pathconf('.', 'PC_PATH_MAX')
 
 # libusb-win32 makes all structures packed, while
 # default libusb only does for some structures


### PR DESCRIPTION
Solaris ships with a libusb0 implementation (that works both with usb devices attached to the host, and those attached to SunRay thin clients served by the host!). But the libusb0 backend wasn't working right because the wrong value was being obtained for PC_PATH_MAX. Fixed here.

One problem remains: the library on Solaris is found at /usr/sfw/lib/libusb.so.1 which is not found automatically by the backend. I am not sure what would be your preferred way to fix that. Just add to the list of names in _load_library? Define a different _load_library if sys.platform is sunos5? Something else?

For right now, the client code in my application is calling get_backend directly to handle this problem, but it will be nice to take that out once the backend can find the library without help.