### PR TITLE
fix get_device_speed for old libusb versions

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -719,7 +719,12 @@ class _LibUSB(usb.backend.IBackend):
         _check(self.lib.libusb_get_device_descriptor(dev.devid, byref(dev_desc)))
         dev_desc.bus = self.lib.libusb_get_bus_number(dev.devid)
         dev_desc.address = self.lib.libusb_get_device_address(dev.devid)
-        dev_desc.speed = self.lib.libusb_get_device_speed(dev.devid)
+
+        # Only available in newer versions of libusb
+        try:
+            dev_desc.speed = self.lib.libusb_get_device_speed(dev.devid)
+        except AttributeError:
+            dev_desc.speed = None
 
         # Only available in newer versions of libusb
         try:


### PR DESCRIPTION
This works for me. Tested on Ubuntu 10.04 (Lucid) with libusb-1.0-0 package version 2:1.0.6-1