### PR TITLE
Fix OpenUSB link

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -593,7 +593,7 @@ Subscribe instructions can be found at the PyUSB_ website.
        no choice.
 
 .. _libusb: http://www.libusb.org
-.. _OpenUSB: http://openusb.wiki.sourceforge.net
+.. _OpenUSB: http://sourceforge.net/p/openusb/wiki/Home/
 .. _USB: http://www.usb.org
 .. _PyUSB: http://pyusb.wiki.sourceforge.net
 .. _Python: http://www.python.org


### PR DESCRIPTION
The link for OpenUSB doesn't work. It says "Page not found" on sourceforge. I replaced it with the link to the OpenUSB sourceforge wiki