### PR TITLE
ctrl_transfer: claim receiving interface for non-VENDOR transfers

### DIFF
--- a/usb/core.py
+++ b/usb/core.py
@@ -1029,7 +1029,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
         recipient = bmRequestType & 3
         rqtype = bmRequestType & (3 << 5)
         if recipient == util.CTRL_RECIPIENT_INTERFACE \
-                and rqtype == util.CTRL_TYPE_STANDARD:
+                and rqtype != util.CTRL_TYPE_VENDOR:
             interface_number = wIndex & 0xff
             self._ctx.managed_claim_interface(self, interface_number)
 


### PR DESCRIPTION
This matches what the Linux kernel does in `check_intf()` when called from `check_ctrlrecip()`
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/drivers/usb/core/devio.c
and thus helps to prevent annoying warnings from the kernel.

The previous code did this for `STANDARD` type transfers already, but not for `CLASS`.