### PR TITLE
make find and find_descriptor easier to understand

### DIFF
--- a/usb/_interop.py
+++ b/usb/_interop.py
@@ -46,6 +46,12 @@ try:
 except (ImportError, AttributeError):
     _reduce = reduce
 
+# all, introduced in Python 2.5
+try:
+    _all = all
+except NameError:
+    _all = lambda iter_ : _reduce( lambda x, y: x and y, iter_, True )
+
 # we only have the builtin set type since 2.5 version
 try:
     _set = set
@@ -90,4 +96,3 @@ def as_array(data=None):
         a = array.array('B')
         a.fromstring(data) # deprecated since 3.2
         return a
-

--- a/usb/core.py
+++ b/usb/core.py
@@ -1242,19 +1242,11 @@ def find(find_all=False, backend = None, custom_match = None, **args):
 
     Backends are explained in the usb.backend module.
     """
-
-    def device_iter(k, v):
+    def device_iter(**kwargs):
         for dev in backend.enumerate_devices():
             d = Device(dev, backend)
-            if  _interop._reduce(
-                        lambda a, b: a and b,
-                        map(
-                            operator.eq,
-                            v,
-                            map(lambda i: getattr(d, i), k)
-                        ),
-                        True
-                    ) and (custom_match is None or custom_match(d)):
+            tests = (val == getattr(d, key) for key, val in kwargs.items())
+            if _interop._all(tests) and (custom_match is None or custom_match(d)):
                 yield d
 
     if backend is None:
@@ -1270,13 +1262,11 @@ def find(find_all=False, backend = None, custom_match = None, **args):
         else:
             raise NoBackendError('No backend available')
 
-    k, v = args.keys(), args.values()
-
     if find_all:
-        return device_iter(k, v)
+        return device_iter(**args)
     else:
         try:
-            return _interop._next(device_iter(k, v))
+            return _interop._next(device_iter(**args))
         except StopIteration:
             return None
 

--- a/usb/util.py
+++ b/usb/util.py
@@ -177,27 +177,17 @@ def find_descriptor(desc, find_all=False, custom_match=None, **args):
     find_descriptor function also accepts the find_all parameter to get
     an iterator instead of just one descriptor.
     """
-    def desc_iter(k, v):
+    def desc_iter(**kwargs):
         for d in desc:
-            if (custom_match is None or custom_match(d)) and \
-                _interop._reduce(
-                        lambda a, b: a and b,
-                        map(
-                            operator.eq,
-                            v,
-                            map(lambda i: getattr(d, i), k)
-                        ),
-                        True
-                    ):
+            tests = (val == getattr(d, key) for key, val in kwargs.items())
+            if _interop._all(tests) and (custom_match is None or custom_match(d)):
                 yield d
 
-    k, v = args.keys(), args.values()
-
     if find_all:
-        return desc_iter(k, v)
+        return desc_iter(**args)
     else:
         try:
-            return _interop._next(desc_iter(k, v))
+            return _interop._next(desc_iter(**args))
         except StopIteration:
             return None
 


### PR DESCRIPTION
all( iter_ ) is more explicit than reduce( lambda x, y:x and y, iter_, True ),
especially since reduce is no longer a builtin.  Use all instead of
complicated multi-line reduce statement for easier code comprehension.
Also, introduce _all interop since all was introduced in 2.5