### PR TITLE
Typo fix: replace LibaryException with LibraryException.

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -669,7 +669,7 @@ def get_backend(find_library=None):
             _setup_prototypes(_lib)
             _lib.usb_init()
         return _LibUSB()
-    except usb.libloader.LibaryException:
+    except usb.libloader.LibraryException:
         # exception already logged (if any)
         _logger.error('Error loading libusb 0.1 backend', exc_info=False)
         return None

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -943,7 +943,7 @@ def get_backend(find_library=None):
             _lib = _load_library(find_library=find_library)
             _setup_prototypes(_lib)
         return _LibUSB(_lib)
-    except usb.libloader.LibaryException:
+    except usb.libloader.LibraryException:
         # exception already logged (if any)
         _logger.error('Error loading libusb 1.0 backend', exc_info=False)
         return None

--- a/usb/backend/openusb.py
+++ b/usb/backend/openusb.py
@@ -740,7 +740,7 @@ def get_backend(find_library=None):
             _setup_prototypes(_lib)
             _ctx = _Context()
         return _OpenUSB()
-    except usb.libloader.LibaryException:
+    except usb.libloader.LibraryException:
         # exception already logged (if any)
         _logger.error('Error loading OpenUSB backend', exc_info=False)
         return None

--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -34,7 +34,7 @@ import logging
 import sys
 
 __all__ = [
-            'LibaryException',
+            'LibraryException',
             'LibraryNotFoundException',
             'NoLibraryCandidatesException',
             'LibraryNotLoadedException',
@@ -48,19 +48,19 @@ __all__ = [
 _LOGGER = logging.getLogger('usb.libloader')
 
 
-class LibaryException(OSError):
+class LibraryException(OSError):
     pass
 
-class LibraryNotFoundException(LibaryException):
+class LibraryNotFoundException(LibraryException):
     pass
 
 class NoLibraryCandidatesException(LibraryNotFoundException):
     pass
 
-class LibraryNotLoadedException(LibaryException):
+class LibraryNotLoadedException(LibraryException):
     pass
 
-class LibraryMissingSymbolsException(LibaryException):
+class LibraryMissingSymbolsException(LibraryException):
     pass
 
 


### PR DESCRIPTION
I actually realize you might want to keep this typo to prevent a breaking change, but it's an easy fix I thought I'd offer.