### PR TITLE
usb/libloader.py: load_locate_library parameter documentation

### DIFF
--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -140,9 +140,9 @@ def load_locate_library(candidates, cygwin_lib, name,
     * name          -- lib identifier (for logging). Defaults to None.
     * win_cls       -- class that is used to instantiate the library on
                        win32 platforms. Defaults to None (-> ctypes.CDLL).
-    * other_cls     -- library class for cygwin platforms.
+    * cygwin_cls    -- library class for cygwin platforms.
                        Defaults to None (-> ctypes.CDLL).
-    * cygwin_cls    -- library class for all other platforms.
+    * others_cls    -- library class for all other platforms.
                        Defaults to None (-> ctypes.CDLL).
     * find_library  -- see locate_library(). Defaults to None.
     * check_symbols -- either None or a list of symbols that the loaded lib


### PR DESCRIPTION
The documentation of cygwin_cls and others_cls got mixed up.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>