### PR TITLE
.gitignore pyusb.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ChangeLog
 MANIFEST
 dist
 .tox
+*.egg-info


### PR DESCRIPTION
And any other .egg-info directories that might be added by setuptools.