### PR TITLE
Update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2009-2014 Wander Lairson Costa. All Rights Reserved.
+Copyright (C) 2009-2017 Wander Lairson Costa. All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/usb/__init__.py
+++ b/usb/__init__.py
@@ -46,7 +46,7 @@ import os
 __author__ = 'Wander Lairson Costa'
 
 # Use Semantic Versioning, http://semver.org/
-version_info = (1, 0, 0)
+version_info = (1, 0, 1)
 __version__ = '%d.%d.%d' % version_info
 
 __all__ = ['legacy', 'control', 'core', 'backend', 'util', 'libloader']


### PR DESCRIPTION
…tarball name needs to match case sensitive the package name defined in setup.py

New release on pypi with new version. tarball name needs to match package name.

pypi not allows replacing tarball for existing version any more, so we're forced to bump version.